### PR TITLE
Add more info about CAN messages

### DIFF
--- a/can_bus/gen1.md
+++ b/can_bus/gen1.md
@@ -133,6 +133,13 @@ Channel name | Equation | Notes
 Hand brake on | `(G & 8) / 8` |
 Brake pedal pressed | `(G & 16) / 16` |
 
+### CAN ID 0x282 (642)
+
+Update frequency: ~16 times per second.
+
+Channel name | Equation | Notes
+------------ | -------- | -----
+Seatbelt plugged in | `(F & 1) == 0` | Only tested driver's side seatbelt. Passenger side might use a different flag or the same flag.
 
 ### CAN ID 0x360 (864)
 
@@ -153,6 +160,27 @@ Update frequency: 20 times per second.
 Channel name | Equation | Notes
 ------------ | -------- | -----
 Gear | A & 0x7 | Not tested
+
+### CAN ID 0x374 (884)
+
+Update frequency: 1 time per second.
+
+Channel name | Equation | Notes
+------------ | -------- | -----
+Driver's door open | `D & 1` | Tested on a RHD car. The equation for driver and passenger door open might be swapped for LHD cars.
+Passenger's door open | `(D & 2) / 2` | Tested on a RHD car. The equation for passenger and driver door open might be swapped for LHD cars.
+Fog lights on | `(B & 128) / 128` | Flag is only set when the main lights are on (parking or full).
+
+### CAN ID 0x375 (885)
+
+Update frequency: 1 time per second.
+
+Channel name | Equation | Notes
+------------ | -------- | -----
+Driver's door open | `B & 1` | Tested on a RHD car. The equation for driver and passenger door open might be swapped for LHD cars.
+Passenger's door open | `(B & 2) / 2` | Tested on a RHD car. The equation for passenger and driver door open might be swapped for LHD cars.
+Either door open | `(D & 4) / 4` | May also be flagged if boot is open. Haven't tested.
+Lights on | `(D & 8) / 8` | Flag is set for both parking lights and full lights.
 
 ### Would be nice to find CAN IDs for ...
 

--- a/can_bus/gen1.md
+++ b/can_bus/gen1.md
@@ -116,6 +116,24 @@ Gear | `(G & 0xf) * (1 - (min(G & 0xf, 7)) / 7)` | It's basically just `G & 0xf`
 ??? | `G & 0xF0` | I saw values of 128, 160, 192 here.
 ??? | `H` | Equals to 16 when I lift off the accelerator, then turns to 8, then 0.
 
+### CAN ID 0x144 (324)
+
+Update frequency: 50 times per second.
+
+Channel name | Equation | Notes
+------------ | -------- | -----
+Brake pedal pressed | `(G & 8) / 8` |
+
+### CAN ID 0x152 (338)
+
+Update frequency: 50 times per second.
+
+Channel name | Equation | Notes
+------------ | -------- | -----
+Hand brake on | `(G & 8) / 8` |
+Brake pedal pressed | `(G & 16) / 16` |
+
+
 ### CAN ID 0x360 (864)
 
 Update frequency: 20 times per second.

--- a/can_bus/gen1.md
+++ b/can_bus/gen1.md
@@ -170,6 +170,7 @@ Channel name | Equation | Notes
 Driver's door open | `D & 1` | Tested on a RHD car. The equation for driver and passenger door open might be swapped for LHD cars.
 Passenger's door open | `(D & 2) / 2` | Tested on a RHD car. The equation for passenger and driver door open might be swapped for LHD cars.
 Fog lights on | `(B & 128) / 128` | Flag is only set when the main lights are on (parking or full).
+Boot open | `(D & 32) / 32` |
 
 ### CAN ID 0x375 (885)
 
@@ -179,7 +180,8 @@ Channel name | Equation | Notes
 ------------ | -------- | -----
 Driver's door open | `B & 1` | Tested on a RHD car. The equation for driver and passenger door open might be swapped for LHD cars.
 Passenger's door open | `(B & 2) / 2` | Tested on a RHD car. The equation for passenger and driver door open might be swapped for LHD cars.
-Either door open | `(D & 4) / 4` | May also be flagged if boot is open. Haven't tested.
+Boot open | `(B & 32) / 32` |
+Either door open | `(D & 4) / 4` | Only flagged when either door is open. Not flagged for the boot.
 Lights on | `(D & 8) / 8` | Flag is set for both parking lights and full lights.
 
 ### Would be nice to find CAN IDs for ...


### PR DESCRIPTION
This PR adds some more info to the gen1 CAN mappings.

Specifically the info is about

+ Brake pedal pressed.
+ Hand brake on.
+ Seatbelt plugged in.
+ Doors/boot open.

None of this info is particularly interesting, but knowing about its presence means the data can be filtered better when looking for other signals/messages.

I'm mostly interested in finding the signals for intake air temperature and manifold absolute pressure, but haven't had any luck finding them yet. There is a decent chance these aren't actually passively on the CAN bus, so sending OBD-II requests would be the only way to get them.