### PR TITLE
Add Karcepts bars

### DIFF
--- a/mods/arbs.md
+++ b/mods/arbs.md
@@ -19,7 +19,9 @@ Cusco 16 mm (965 311 A16) | 111
 OEM Gen 1 | 141
 Perrin 19 mm | 176 | 242 | Might experience fitment issues, such as end links hitting the FLCA at full droop, and/or the tires hitting the ARB at full lock under load
 ST Suspension 19 mm | 199 | 248
+Karcepts 0.804 in | 235 | 375 | Uses Karcepts end links, has intermediate positions between listed rates
 Cusco 20 mm (965 311 A20) | 245
+Karcepts 0.875 in | 299 | 475 | Uses Karcepts end links, has intermediate positions between listed rates
 Whiteline 20 mm | 306 | 437
 Perrin 22 mm | 324 | 448
 Whiteline 22 mm | 440 | 547

--- a/mods/arbs.md
+++ b/mods/arbs.md
@@ -16,7 +16,7 @@ are provided in lbs/in (shame on me), rounded to the nearest integer.
 Product name | Softest | Stiffest | Notes
 ------------ | ------- | -------- | -----
 Cusco 16 mm (965 311 A16) | 111
-Gen1 OE | 141
+OEM Gen 1 | 141
 Perrin 19 mm | 176 | 242 | Might experience fitment issues, such as end links hitting the FLCA at full droop, and/or the tires hitting the ARB at full lock under load
 ST Suspension 19 mm | 199 | 248
 Cusco 20 mm (965 311 A20) | 245
@@ -29,10 +29,13 @@ Eibach 25 mm | 500 | 585
 
 Product name | Softest | Middle | Stiffest | Notes
 ------------ | ------- | ------ | -------- | -----
-Mann 13 mm   | 72 | 89 | 113 | Requires a spacer between the subframe and the bushings, likely won't work on gen2 BRZs
+Karcepts 0.095 in | 64 | 81 | 109 | Uses Karcepts end links, has intermediate positions between listed rates
+Karcepts 0.120 in | 71 | 90 | 122 | Uses Karcepts end links, has intermediate positions between listed rates
+Mann Engineering 13 mm   | 72 | 89 | 113 | Requires a spacer between the subframe and the bushings, likely won't work on gen2 BRZs
 Cusco 14 mm (965 311 B14) | 82
-Early gen1s | 113
-2017+ gen1 Subaru BRZ | 140
+Karcepts Solid | 84 | 105 | 142 | Uses Karcepts end links, has intermediate positions between listed rates
+OEM 2013-2016 Gen 1 14 mm | 113
+OEM 2017+ Gen 1 15 mm | 140
 Perrin 16 mm | 147 | 186 | 244 | Requires Perrin end links for some positions
 Whiteline 16 mm | 158 | 214 | 312
 Cusco 16 mm (965 311 B16) | 190


### PR DESCRIPTION
These rates are as supplied to me by Karcepts.

For what it is worth, Karcepts same data shows that the Mann Engineering bar is 43lb, 53lb, and 75lb.  Their stock bar rates are 111lb and 146lb.  I'll let you decide to do what you'd like with those numbers.