### PR TITLE
update gear info for AT model

### DIFF
--- a/can_bus/gen2.md
+++ b/can_bus/gen2.md
@@ -161,16 +161,16 @@ Example values:\
 `d9 4f 8a 04 10 a1 03 00` (P)\
 `b0 4b 7b 03 10 8d 02 00` (R)\
 
-| Channel name | Equation                                     | Notes                                                        |
-| ------------ | -------------------------------------------- | ------------------------------------------------------------ |
-| N engaged    | `(D & 0x02) == 0x02`                         |                                                              |
-| P engaged    | `(D & 0x04) == 0x04`                         |                                                              |
-| R engaged    | `(D & 0x03) == 0x03`                         |                                                              |
-| D engaged    | `D == 0x79`                                  |                                                              |
-| M engaged    | `D & 0x80`                                   | Manual Mode.                                                 |
-| Gear (M)     | if((D & 0x80), (D & 0x38 >> 3), NaN)         | Mask 0x38 for gear under M mode.                             |
-| S engaged    | `(D & 0x03) == 0x01`                         | Sports Mode. Bit `0` flags sport mode.                       |
-| Gear (S)     | if((D & 0x01), (((D & 0x78) >> 3) - 6), NaN) | Mask 0x78 for gear under S mode, `- 6` to get actual gear position. |
+| Channel name | Equation                                       | Notes                                                        |
+| ------------ | ---------------------------------------------- | ------------------------------------------------------------ |
+| N engaged    | `(D & 0x02) == 0x02`                           |                                                              |
+| P engaged    | `(D & 0x04) == 0x04`                           |                                                              |
+| R engaged    | `(D & 0x03) == 0x03`                           |                                                              |
+| D engaged    | `D == 0x79`                                    |                                                              |
+| M engaged    | `D & 0x80`                                     | Manual Mode.                                                 |
+| Gear (M)     | `if((D & 0x80), (D & 0x38 >> 3), NaN)`         | Mask 0x38 for gear under M mode.                             |
+| S engaged    | `(D & 0x03) == 0x01`                           | Sports Mode. Bit `0` flags sport mode.                       |
+| Gear (S)     | `if((D & 0x01), (((D & 0x78) >> 3) - 6), NaN)` | Mask 0x78 for gear under S mode, `- 6` to get actual gear position. |
 
 ### CAN ID 0x118 (280)
 


### PR DESCRIPTION
Only tested on CN market AT model.
PID and recorded count in a while, normalize with the freq measured previously to get actual freq.
| PID   | Recorded count
| ----- | ---------
| 0x6e2 |        28
| 0x6e1 |        28
| 0x6df |        23
| 0x6b1 |        23
| 0x68d |        24
| 0x68c |        23
| 0x663 |        28
| 0x660 |        56
| 0x654 |        23
| 0x652 |        23
| 0x651 |        24
| 0x640 |        23
| 0x517 |        56
| 0x50b |        56
| 0x509 |        56
| 0x506 |        56
| 0x500 |        56
| 0x3d9 |       140
| 0x3ac |       278
| 0x3a7 |       278
| 0x3a2 |       279
| 0x39a |       140
| 0x393 |       279
| 0x390 |       279
| 0x34a |       279
| 0x345 |       280
| 0x33b |       233
| 0x33a |       233
| 0x332 |       233
| 0x330 |       232
| 0x32b |       280
| 0x328 |       280
| 0x325 |       279
| 0x323 |       279
| 0x322 |       279
| 0x321 |       279
| 0x2d2 |       466
| 0x241 |       402
| 0x22a |       463
| 0x228 |       465
| 0x146 |       466
| 0x143 |       466
| 0x13c |       466
| 0x13b |       466
| 0x139 |       466
| 0x138 |       466
| 0x118 |       466
| 0x048 |       545
| 0x041 |       549
| 0x040 |       551| 