### PR TITLE
feat: add ATF temp

### DIFF
--- a/can_bus/gen2.md
+++ b/can_bus/gen2.md
@@ -309,6 +309,16 @@ Channel name | Equation | Notes
 Engine oil temperature | `D - 40` |
 Coolant temperature | `E - 40` |
 
+### CAN ID 0x34A (837)
+
+This channel only available on AT model.
+
+Update frequency: 10 times per second.
+
+Channel name | Equation | Notes
+------------ | -------- | -----
+AT fluid temperature | `E - 40` | Inaccurate at low temperatures
+
 ### CAN ID 0x390 (912)
 
 Update frequency: 10 times per second.

--- a/can_bus/gen2.md
+++ b/can_bus/gen2.md
@@ -317,7 +317,7 @@ Update frequency: 10 times per second.
 
 Channel name | Equation | Notes
 ------------ | -------- | -----
-AT fluid temperature | `E - 40` | Inaccurate at low temperatures
+AT fluid temperature | `E - 50` |
 
 ### CAN ID 0x390 (912)
 


### PR DESCRIPTION
Tested and verified on a 2025 GR86 6AT. This CAN ID appears to be AT-exclusive.

Validation Summary:
1. Stall Test: Holding brake in D with throttle produces a real-time temperature spike after a 2-4s thermal propagation delay.
2. Cooling Rate: Engine-off cooling curve matches the thermal inertia of the transmission assembly.
3. Cold Start Alignment: Adjusted the offset to -50, which perfectly matches ambient air and coolant temperatures during cold starts.
4. Community Cross-Verification: Aligns with independent data from Chinese platform developer '6mb', who noted a 10°C downward variance from the generic -40 standard formulas, confirming the mathematical validity of our -50 adjustment.

Submitting as an RFC for other Gen2 AT data loggers to cross-verify.